### PR TITLE
fixing cases where depth is None and when container without len is encountered

### DIFF
--- a/python_ls/_ls.py
+++ b/python_ls/_ls.py
@@ -29,7 +29,7 @@ def ls(obj, attr=None, depth=None, dunder=False, under=True):
         size = ''
         if has_pandas and isinstance(value, pd.DataFrame):
             size = '{0}x{1}'.format(*value.shape)
-        elif isinstance(value, Container):
+        elif hasattr(value, '__len__'):
             size = len(value)
         type_name = type(value).__name__
         print('{:<60}{:>20}{:>7}'.format(attr, type_name, size))
@@ -46,7 +46,7 @@ def iter_ls(obj, attr=None, depth=1, dunder=False, under=True,
             visited=None, current_depth=1, path=''):
     visited = visited or set()
 
-    if current_depth <= depth:
+    if (depth is None) or (current_depth <= depth):
         if id(obj) not in visited:
             visited.add(id(obj))
 

--- a/tests/test_ls.py
+++ b/tests/test_ls.py
@@ -16,7 +16,6 @@ def test_obj():
     o.foo.bar.bbb = Object()
     o.foo.bar._something_else = lambda: None
     o.foo.baz = {'something_weird': 'going on', 'blah': 'bleh'}
-
     o.lala = Object()
     o.lala.lele = Object()
     o.lala.something = Object()
@@ -39,3 +38,16 @@ def test_ls_recursive(test_obj):
 
     actual = [x[0] for x in iter_ls(test_obj, 'something', depth=4)]
     assert actual == expected
+
+
+def test_depth_is_None(test_obj):
+    expected = [
+        'foo.bar._something_else()',
+        'foo.bar.something',
+        "foo.baz['something_weird']",
+        'lala.something',
+    ]
+
+    actual = [x[0] for x in iter_ls(test_obj, 'something', depth=None)]
+    assert actual == expected
+

--- a/tests/test_ls.py
+++ b/tests/test_ls.py
@@ -14,7 +14,7 @@ def test_obj():
     o.foo.bar.something = Object()
     o.foo.bar.aaa = Object()
     o.foo.bar.bbb = Object()
-    o.foo.bar._something_else = lambda: None
+    o.foo.bar._something_else = dict  # a callable (lambda recurses infinitely in Python 2.7 when depth=None)
     o.foo.baz = {'something_weird': 'going on', 'blah': 'bleh'}
     o.lala = Object()
     o.lala.lele = Object()


### PR DESCRIPTION
and when container without len is encountered. For example when obj is re (regex module). To fix raised issue - https://github.com/gabrielcnr/python-ls/issues/6