### PR TITLE
Container test and depth default

### DIFF
--- a/python_ls/_ls.py
+++ b/python_ls/_ls.py
@@ -21,7 +21,7 @@ def ls(obj, attr=None, depth=None, dunder=False, under=True):
     :param under: If True single underscore prefixed attributes are ignored, default is enabled
     :return: None
     """
-    if depth is None and attr is None:
+    if depth is None:
         depth = 1
 
     for attr, value in iter_ls(obj, attr=attr, depth=depth,
@@ -31,6 +31,7 @@ def ls(obj, attr=None, depth=None, dunder=False, under=True):
             size = '{0}x{1}'.format(*value.shape)
         elif isinstance(value, Container):
             size = len(value)
+
         type_name = type(value).__name__
         print('{:<60}{:>20}{:>7}'.format(attr, type_name, size))
 

--- a/python_ls/_ls.py
+++ b/python_ls/_ls.py
@@ -29,9 +29,12 @@ def ls(obj, attr=None, depth=None, dunder=False, under=True):
         size = ''
         if has_pandas and isinstance(value, pd.DataFrame):
             size = '{0}x{1}'.format(*value.shape)
-        elif isinstance(value, Container):
-            size = len(value)
-
+        else:
+            try:
+                size = len(value)
+            except:
+                pass
+            
         type_name = type(value).__name__
         print('{:<60}{:>20}{:>7}'.format(attr, type_name, size))
 


### PR DESCRIPTION
Thanks for ls, very much enjoying it.

There are a couple of fixes here -- although I notice there is already a pull request with similar fixes

First, if you pass in an attribute to look for but don't pass depth then you get an error due to depth being None.   I fixed this by setting depth to 1 if it is None, regardless of attr value

I was using this with matplotlib and found

ls(axes)

Throwing an error that it couldn't run len on a Grouper object.

Turns out that isinstance thinks anything with a __contains__ method is a Container.

This fix just calls len(value) regardless and ignores the except

Below: code to demonstrate this:

from collections import Container

class Foo(object):

    def __init__(self):

        self.data = [1, 2, 3]

    def __contains__(self, value):

        return value in self.data


f = Foo()

print(isinstance(f, Container))


