### PR TITLE
Fix import error in Python 3.11

### DIFF
--- a/python_ls/_ls.py
+++ b/python_ls/_ls.py
@@ -1,4 +1,7 @@
-from collections import Container
+try:
+    from collections import Container
+except ImportError:
+    from collections.abc import Container
 
 try:
     import pandas as pd


### PR DESCRIPTION
Container import has moved in Python 3.11