### PR TITLE
Add wildcard/glob pattern support with case-insensitive attr search

### DIFF
--- a/python_ls/_ls.py
+++ b/python_ls/_ls.py
@@ -1,3 +1,4 @@
+import fnmatch
 from collections.abc import Iterator
 from typing import Any
 
@@ -10,6 +11,12 @@ else:
 
 # sentinel for attributes that could not be retrieved
 BAD = object()
+
+_GLOB_CHARS = frozenset("*?[]")
+
+
+def _has_glob_chars(pattern: str) -> bool:
+    return any(c in _GLOB_CHARS for c in pattern)
 
 
 def ls(
@@ -97,7 +104,12 @@ def iter_ls(
                 return all(f(a) for f in filters)
 
             if attr:
-                filters.append(lambda a: attr in a)
+                if _has_glob_chars(attr):
+                    attr_lower = attr.lower()
+                    filters.append(lambda a: fnmatch.fnmatchcase(a.lower(), attr_lower))
+                else:
+                    attr_lower = attr.lower()
+                    filters.append(lambda a: attr_lower in a.lower())
 
             if not dunder:
                 filters.append(lambda a: not a.startswith("__"))

--- a/tests/test_ls.py
+++ b/tests/test_ls.py
@@ -1,4 +1,5 @@
 from python_ls import iter_ls
+from python_ls._ls import _has_glob_chars
 import pytest
 
 
@@ -50,4 +51,58 @@ def test_depth_is_None(test_obj):
 
     actual = [x[0] for x in iter_ls(test_obj, 'something', depth=None)]
     assert actual == expected
+
+
+class TestHasGlobChars:
+    def test_plain_string(self):
+        assert not _has_glob_chars("something")
+
+    def test_star(self):
+        assert _has_glob_chars("get_*")
+
+    def test_question_mark(self):
+        assert _has_glob_chars("fo?")
+
+    def test_brackets(self):
+        assert _has_glob_chars("[abc]")
+
+
+class TestAttrGlobPattern:
+    def test_star_prefix(self, test_obj):
+        """*thing should match 'something' but not via substring."""
+        attrs = [path.split(".")[-1] for path, _ in iter_ls(test_obj, "*oo", depth=1)]
+        assert attrs == ["foo"]
+
+    def test_star_suffix(self, test_obj):
+        attrs = [path for path, _ in iter_ls(test_obj, "la*", depth=1)]
+        assert attrs == ["lala"]
+
+    def test_star_middle(self, test_obj):
+        """Glob *a* at depth=2 matches bar, baz, lala, lele via fnmatch."""
+        attrs = [path.split(".")[-1].rstrip("()") for path, _ in iter_ls(test_obj, "*a*", depth=2)]
+        assert "bar" in attrs
+        assert "baz" in attrs
+
+    def test_question_mark(self, test_obj):
+        attrs = [path for path, _ in iter_ls(test_obj, "fo?", depth=2)]
+        assert "foo" in attrs
+
+    def test_character_class(self, test_obj):
+        attrs = [path.split(".")[-1] for path, _ in iter_ls(test_obj, "[fb]*", depth=2)]
+        assert "foo" in attrs
+        assert "bar" in attrs
+        assert "baz" in attrs
+
+    def test_plain_attr_still_does_substring(self, test_obj):
+        """Plain string without glob chars should still do substring matching."""
+        attrs = [path.split(".")[-1].rstrip("()") for path, _ in iter_ls(test_obj, "omethin", depth=2)]
+        assert "something" in attrs
+
+    def test_case_insensitive_substring(self, test_obj):
+        attrs = [path for path, _ in iter_ls(test_obj, "FOO", depth=1)]
+        assert "foo" in attrs
+
+    def test_case_insensitive_glob(self, test_obj):
+        attrs = [path for path, _ in iter_ls(test_obj, "FO*", depth=1)]
+        assert "foo" in attrs
 


### PR DESCRIPTION
Use fnmatch for glob patterns (*, ?, []) in the attr parameter, falling back to substring matching for plain strings. All matching is now case-insensitive.