### PR TITLE
Guard property detection against C extension types without __dict__

### DIFF
--- a/python_ls/_ls.py
+++ b/python_ls/_ls.py
@@ -36,9 +36,12 @@ def _get_mro(obj: Any) -> tuple[type, ...]:
 
 
 def _is_property(obj: Any, attr_name: str) -> bool:
-    for cls in _get_mro(obj):
-        if attr_name in vars(cls) and isinstance(vars(cls)[attr_name], property):
-            return True
+    try:
+        for cls in _get_mro(obj):
+            if attr_name in vars(cls) and isinstance(vars(cls)[attr_name], property):
+                return True
+    except TypeError:
+        pass
     return False
 
 
@@ -52,15 +55,18 @@ def _get_property_type_hint(obj: Any, attr_name: str) -> type | None:
     except Exception:
         pass
     # Try the property getter's return annotation
-    for cls in _get_mro(obj):
-        if attr_name in vars(cls):
-            prop = vars(cls)[attr_name]
-            if isinstance(prop, property) and prop.fget is not None:
-                try:
-                    hints = typing.get_type_hints(prop.fget)
-                    return hints.get("return")
-                except Exception:
-                    pass
+    try:
+        for cls in _get_mro(obj):
+            if attr_name in vars(cls):
+                prop = vars(cls)[attr_name]
+                if isinstance(prop, property) and prop.fget is not None:
+                    try:
+                        hints = typing.get_type_hints(prop.fget)
+                        return hints.get("return")
+                    except Exception:
+                        pass
+    except TypeError:
+        pass
     return None
 
 

--- a/tests/test_ls.py
+++ b/tests/test_ls.py
@@ -348,3 +348,35 @@ class TestPropertySafety:
         assert "inner.deep" in result
         assert "inner.deep.z" in result
 
+
+class TestCExtensionTypes:
+    def test_ls_datetime(self):
+        """C extension objects like datetime should not crash."""
+        import datetime
+
+        result = list(iter_ls(datetime.datetime.now()))
+        paths = [p for p, _ in result]
+        assert "year" in paths
+        assert "month" in paths
+        assert "day" in paths
+
+    def test_ls_slots_object(self):
+        """Objects with __slots__ and no __dict__ should work."""
+        class Slotted:
+            __slots__ = ("x", "y")
+
+        obj = Slotted()
+        obj.x = 42
+        obj.y = "hello"
+        result = list(iter_ls(obj))
+        paths = [p for p, _ in result]
+        assert "x" in paths
+        assert "y" in paths
+
+    def test_ls_int(self):
+        """Builtin types like int should not crash."""
+        result = list(iter_ls(42))
+        paths = [p for p, _ in result]
+        assert "real" in paths
+        assert "imag" in paths
+


### PR DESCRIPTION
Wrap _is_property and _get_property_type_hint MRO traversal in try/except TypeError so objects from compiled extensions (datetime, __slots__-only classes, builtins) fall back safely to getattr.