### PR TITLE
Add value=True parameter to ls() for showing attribute values

### DIFF
--- a/python_ls/_ls.py
+++ b/python_ls/_ls.py
@@ -78,6 +78,19 @@ def _type_hint_name(hint: Any) -> str:
     return str(hint)
 
 
+_VALUE_MAX_WIDTH = 40
+
+
+def _truncate_repr(value: Any, max_width: int = _VALUE_MAX_WIDTH) -> str:
+    try:
+        r = repr(value)
+    except Exception:
+        return "<?>"
+    if len(r) > max_width:
+        return r[: max_width - 3] + "..."
+    return r
+
+
 def ls(
     obj: Any,
     attr: str | None = None,
@@ -85,6 +98,7 @@ def ls(
     dunder: bool = False,
     under: bool = True,
     type: type | tuple[type, ...] | str | None = None,
+    value: bool = False,
 ) -> None:
     """
     Recursively search for a named attribute in an object and print matches.
@@ -94,25 +108,32 @@ def ls(
     :param depth: Maximum search depth, defaults to 1 (no recursion)
     :param dunder: If True, double-underscore prefixed attributes are included (default: excluded)
     :param under: If True, single-underscore prefixed attributes are included (default: included)
+    :param value: If True, show a truncated repr of each attribute's value
     """
     if depth is None:
         depth = 1
 
-    for attr_path, value in iter_ls(obj, attr=attr, depth=depth, dunder=dunder, under=under, type=type):
+    for attr_path, val in iter_ls(obj, attr=attr, depth=depth, dunder=dunder, under=under, type=type):
         size: int | str = ""
-        if isinstance(value, PropertyInfo):
-            if value.type_hint is not None:
-                type_name = f"property[{_type_hint_name(value.type_hint)}]"
+        if isinstance(val, PropertyInfo):
+            if val.type_hint is not None:
+                type_name = f"property[{_type_hint_name(val.type_hint)}]"
             else:
                 type_name = "property"
-        elif has_pandas and isinstance(value, pd.DataFrame):
-            size = "{0}x{1}".format(*value.shape)
-            type_name = _type(value).__name__
+        elif has_pandas and isinstance(val, pd.DataFrame):
+            size = "{0}x{1}".format(*val.shape)
+            type_name = _type(val).__name__
         else:
-            if hasattr(value, "__len__"):
-                size = len(value)
-            type_name = _type(value).__name__
-        print("{:<60}{:>20}{:>7}".format(attr_path, type_name, size))
+            if hasattr(val, "__len__"):
+                size = len(val)
+            type_name = _type(val).__name__
+        line = "{:<60}{:>20}{:>7}".format(attr_path, type_name, size)
+        if value:
+            if isinstance(val, PropertyInfo):
+                line += "  <property>"
+            else:
+                line += "  " + _truncate_repr(val)
+        print(line)
 
 
 def xdir(

--- a/tests/test_ls.py
+++ b/tests/test_ls.py
@@ -1,5 +1,5 @@
 from python_ls import PropertyInfo, iter_ls
-from python_ls._ls import _has_glob_chars
+from python_ls._ls import _has_glob_chars, _truncate_repr, ls
 import pytest
 
 
@@ -379,4 +379,62 @@ class TestCExtensionTypes:
         paths = [p for p, _ in result]
         assert "real" in paths
         assert "imag" in paths
+
+
+class TestTruncateRepr:
+    def test_short_value(self):
+        assert _truncate_repr(42) == "42"
+
+    def test_string_value(self):
+        assert _truncate_repr("hello") == "'hello'"
+
+    def test_long_value_truncated(self):
+        long_list = list(range(100))
+        result = _truncate_repr(long_list, max_width=20)
+        assert len(result) == 20
+        assert result.endswith("...")
+
+    def test_repr_error(self):
+        class Bad:
+            def __repr__(self):
+                raise RuntimeError("boom")
+
+        assert _truncate_repr(Bad()) == "<?>"
+
+
+class TestValueDisplay:
+    def test_value_false_by_default(self, capsys):
+        o = Object()
+        o.x = 42
+        ls(o)
+        output = capsys.readouterr().out
+        assert "42" not in output
+
+    def test_value_true_shows_repr(self, capsys):
+        o = Object()
+        o.x = 42
+        o.y = "hello"
+        ls(o, value=True)
+        output = capsys.readouterr().out
+        assert "42" in output
+        assert "'hello'" in output
+
+    def test_value_property_shows_placeholder(self, capsys):
+        class Obj:
+            @property
+            def name(self) -> str:
+                raise RuntimeError("should not be called")
+
+        ls(Obj(), value=True)
+        output = capsys.readouterr().out
+        assert "<property>" in output
+
+    def test_value_long_repr_truncated(self, capsys):
+        o = Object()
+        o.data = "a" * 200
+        ls(o, value=True)
+        output = capsys.readouterr().out
+        assert "..." in output
+        # Full repr would be 202 chars ('a...a'), should be truncated
+        assert "a" * 200 not in output
 


### PR DESCRIPTION
When enabled, appends a truncated repr of each value after the existing type/size columns. Properties show <property> instead. Long reprs are truncated to 40 chars with ellipsis.